### PR TITLE
user router の追加

### DIFF
--- a/consts/const.go
+++ b/consts/const.go
@@ -8,9 +8,12 @@ const (
 	CookieHttpOnly      = true
 	CookieSessionMaxAge = 60 * 60 * 24 * 7
 	CookieCSRFMaxAge    = 60 * 15
-	UserEmail           = "email_address"
-	ClubSlugKeyName     = "club_slug"
-	UserUUID            = "user_uuid"
+	SessionUserEmail    = "sess_user_email"
+	SessionUserUUID     = "sess_user_uuid"
+	SessionUserName     = "sess_user_name"
+	SessionUserRole     = "sess_user_role"
+	ClubSlugKeyName     = "club_slug_key"
+	UserUUIDKeyName     = "user_uuid_key"
 )
 
 // CampusType サークルのキャンパスタイプ (0: 蒲田, 1: 八王子)

--- a/consts/const.go
+++ b/consts/const.go
@@ -19,24 +19,36 @@ const (
 // CampusType サークルのキャンパスタイプ (0: 蒲田, 1: 八王子)
 type CampusType uint8
 
-func (ct CampusType) ToPrimitive() uint8 {
-	return uint8(ct)
-}
-
 const (
 	CampusKamata   CampusType = 0
 	CampusHachioji CampusType = 1
 )
 
-// ClubType サークルの種類 (0: 体育会系, 1: 文化会系, 2: 実行委員会)
-type ClubType uint8
-
-func (ct ClubType) ToPrimitive() uint8 {
+func (ct CampusType) ToPrimitive() uint8 {
 	return uint8(ct)
 }
+
+// ClubType サークルの種類 (0: 体育会系, 1: 文化会系, 2: 実行委員会)
+type ClubType uint8
 
 const (
 	SportsType  ClubType = 0
 	CultureType ClubType = 1
 	KokasaiType ClubType = 2
 )
+
+func (ct ClubType) ToPrimitive() uint8 {
+	return uint8(ct)
+}
+
+type UserType string
+
+const (
+	DomainUser  UserType = "domain"
+	GeneralUser UserType = "general"
+	AdminUser   UserType = "admin"
+)
+
+func (ut UserType) ToPrimitive() string {
+	return string(ut)
+}

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -21,7 +21,3 @@ email_domains = [
 admin_emails = [
 
 ]
-
-general_emails = [
-
-]

--- a/models/user.go
+++ b/models/user.go
@@ -7,6 +7,7 @@ type UserInfo interface {
 	GetEmail() string
 	GetName() string
 	GetRole() string
+	ToUserResponse() *UserResponse
 }
 
 type DomainUser struct {
@@ -33,6 +34,17 @@ func (u *DomainUser) GetName() string {
 func (u *DomainUser) GetRole() string {
 	role := "domain"
 	return role
+}
+
+func (u *DomainUser) ToUserResponse() *UserResponse {
+	res := &UserResponse{
+		UserUUID: u.UserUUID,
+		Email:    u.Email,
+		Name:     u.Name,
+		Role:     u.GetRole(),
+	}
+
+	return res
 }
 
 type GeneralUser struct {
@@ -62,6 +74,17 @@ func (u *GeneralUser) GetRole() string {
 	return role
 }
 
+func (u *GeneralUser) ToUserResponse() *UserResponse {
+	res := &UserResponse{
+		UserUUID: u.UserUUID,
+		Email:    u.Email,
+		Name:     u.Name,
+		Role:     u.GetRole(),
+	}
+
+	return res
+}
+
 type AdminUser struct {
 	UserUUID string `gorm:"type:char(36);not null;primaryKey"`
 	Email    string `gorm:"type:varchar(255);not null;unique"`
@@ -86,6 +109,17 @@ func (u *AdminUser) GetName() string {
 func (u *AdminUser) GetRole() string {
 	role := "admin"
 	return role
+}
+
+func (u *AdminUser) ToUserResponse() *UserResponse {
+	res := &UserResponse{
+		UserUUID: u.UserUUID,
+		Email:    u.Email,
+		Name:     u.Name,
+		Role:     u.GetRole(),
+	}
+
+	return res
 }
 
 type UserResponse struct {

--- a/models/user.go
+++ b/models/user.go
@@ -128,3 +128,15 @@ type UserResponse struct {
 	Name     string `json:"name"`
 	Role     string `json:"role"`
 }
+
+type GeneralUserSlice []GeneralUser
+
+func (g GeneralUserSlice) GetEmails() []string {
+	emails := make([]string, len(g))
+
+	for i, email := range g {
+		emails[i] = email.GetEmail()
+	}
+
+	return emails
+}

--- a/models/user.go
+++ b/models/user.go
@@ -87,3 +87,10 @@ func (u *AdminUser) GetRole() string {
 	role := "admin"
 	return role
 }
+
+type UserResponse struct {
+	UserUUID string `json:"user_uuid"`
+	Email    string `json:"email"`
+	Name     string `json:"name"`
+	Role     string `json:"role"`
+}

--- a/repos/user.go
+++ b/repos/user.go
@@ -28,7 +28,7 @@ type UserRepo interface {
 
 func (r *Repository) GetAllGeneralUser() ([]models.GeneralUser, error) {
 	users := make([]models.GeneralUser, 0)
-	tx := r.db.Find(users)
+	tx := r.db.Find(&users)
 
 	if err := tx.Error; err != nil {
 		return nil, err

--- a/repos/user.go
+++ b/repos/user.go
@@ -1,10 +1,15 @@
 package repos
 
 import (
-	"errors"
+	"github.com/lc-tut/club-portal/consts"
 	"github.com/lc-tut/club-portal/models"
 	"github.com/lc-tut/club-portal/utils"
 )
+
+type UpdateUserArgs struct {
+	Name     string
+	ClubUUID *string
+}
 
 type UserRepo interface {
 	GetAllGeneralUser() ([]models.GeneralUser, error)
@@ -24,6 +29,8 @@ type UserRepo interface {
 
 	UpdateDomainUser(uuid string, name string) error
 	UpdateGeneralUser(uuid string, name string, clubUUID string) error
+	UpdateAdminUser(uuid string, name string) error
+	UpdateUserFromRole(uuid string, role string, args UpdateUserArgs) error
 }
 
 func (r *Repository) GetAllGeneralUser() ([]models.GeneralUser, error) {
@@ -104,28 +111,34 @@ func (r *Repository) GetAdminUserByEmail(email string) (*models.AdminUser, error
 }
 
 func (r *Repository) GetUserByUUIDFromRole(uuid string, role string) (models.UserInfo, error) {
-	switch role {
-	case "domain":
-		return r.GetDomainUserByUUID(uuid)
-	case "general":
-		return r.GetGeneralUserByUUID(uuid)
-	case "admin":
+	userType, err := utils.ToUserType(role)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if userType == consts.AdminUser {
 		return r.GetAdminUserByUUID(uuid)
-	default:
-		return nil, errors.New("no role: " + role)
+	} else if userType == consts.GeneralUser {
+		return r.GetGeneralUserByUUID(uuid)
+	} else {
+		return r.GetAdminUserByUUID(uuid)
 	}
 }
 
 func (r *Repository) GetUserByEmailFromRole(email string, role string) (models.UserInfo, error) {
-	switch role {
-	case "domain":
-		return r.GetDomainUserByEmail(email)
-	case "general":
-		return r.GetGeneralUserByEmail(email)
-	case "admin":
+	userType, err := utils.ToUserType(role)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if userType == consts.AdminUser {
 		return r.GetAdminUserByEmail(email)
-	default:
-		return nil, errors.New("no role: " + role)
+	} else if userType == consts.GeneralUser {
+		return r.GetGeneralUserByEmail(email)
+	} else {
+		return r.GetAdminUserByEmail(email)
 	}
 }
 
@@ -201,6 +214,42 @@ func (r *Repository) UpdateGeneralUser(uuid string, name string, clubUUID string
 	tx := r.db.Model(&user).Where("user_uuid = ?", uuid).Updates(user)
 
 	if err := tx.Error; err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *Repository) UpdateAdminUser(uuid string, name string) error {
+	user := models.AdminUser{
+		Name: name,
+	}
+
+	tx := r.db.Model(&user).Where("user_uuid = ?", uuid).Updates(user)
+
+	if err := tx.Error; err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *Repository) UpdateUserFromRole(uuid string, role string, args UpdateUserArgs) error {
+	userType, err := utils.ToUserType(role)
+
+	if err != nil {
+		return err
+	}
+
+	if userType == consts.AdminUser {
+		err = r.UpdateAdminUser(uuid, args.Name)
+	} else if userType == consts.GeneralUser {
+		err = r.UpdateGeneralUser(uuid, args.Name, utils.NilToEmptyString(args.ClubUUID))
+	} else {
+		err = r.UpdateDomainUser(uuid, args.Name)
+	}
+
+	if err != nil {
 		return err
 	}
 

--- a/repos/user.go
+++ b/repos/user.go
@@ -20,6 +20,7 @@ type UserRepo interface {
 
 	CreateDomainUser(uuid string, email string, name string) (*models.DomainUser, error)
 	CreateGeneralUser(uuid string, email string, name string) (*models.GeneralUser, error)
+	CreateAdminUser(uuid string, email string, name string) (*models.AdminUser, error)
 
 	UpdateDomainUser(uuid string, name string) error
 	UpdateGeneralUser(uuid string, name string, clubUUID string) error
@@ -150,6 +151,22 @@ func (r *Repository) CreateGeneralUser(uuid string, email string, name string) (
 		Email:    email,
 		Name:     name,
 		ClubUUID: utils.ToNullString(""),
+	}
+
+	tx := r.db.Create(user)
+
+	if err := tx.Error; err != nil {
+		return nil, err
+	}
+
+	return user, nil
+}
+
+func (r *Repository) CreateAdminUser(uuid string, email string, name string) (*models.AdminUser, error) {
+	user := &models.AdminUser{
+		UserUUID: uuid,
+		Email:    email,
+		Name:     name,
 	}
 
 	tx := r.db.Create(user)

--- a/router/auth/callback.go
+++ b/router/auth/callback.go
@@ -108,6 +108,15 @@ func (h *Handler) getUserOrCreate(data *jwtData) (models.UserInfo, error) {
 
 	if h.config.WhitelistUsers.IsAdminUser(email) {
 		user, err = h.repo.GetAdminUserByEmail(email)
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			newUserUUID, _err := uuid.NewRandom()
+
+			if _err != nil {
+				return nil, _err
+			}
+
+			user, err = h.repo.CreateAdminUser(newUserUUID.String(), email, data.Name)
+		}
 	} else if h.config.WhitelistUsers.IsGeneralUser(email) {
 		user, err = h.repo.GetGeneralUserByEmail(email)
 	} else {

--- a/router/middlewares/param.go
+++ b/router/middlewares/param.go
@@ -12,3 +12,11 @@ func (mw *Middleware) SetClubIDKey() gin.HandlerFunc {
 		ctx.Next()
 	}
 }
+
+func (mw *Middleware) SetUserUUIDKey() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		v := ctx.Param("uuid")
+		ctx.Set(consts.UserUUIDKeyName, v)
+		ctx.Next()
+	}
+}

--- a/router/middlewares/permission.go
+++ b/router/middlewares/permission.go
@@ -6,9 +6,56 @@ import (
 	"net/http"
 )
 
+func (mw *Middleware) PersonalOrAdminOnly() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		email := ctx.GetString(consts.SessionUserEmail)
+
+		if mw.config.WhitelistUsers.IsAdminUser(email) {
+			ctx.Next()
+			return
+		}
+
+		sessUUID := ctx.GetString(consts.SessionUserUUID)
+		paramUUID := ctx.GetString(consts.UserUUIDKeyName)
+
+		if sessUUID != paramUUID {
+			ctx.AbortWithStatus(http.StatusForbidden)
+			return
+		}
+
+		ctx.Next()
+	}
+}
+
+func (mw *Middleware) UserOnly() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		email := ctx.GetString(consts.SessionUserEmail)
+
+		if !mw.config.WhitelistUsers.IsUser(email) {
+			ctx.AbortWithStatus(http.StatusForbidden)
+			return
+		}
+
+		ctx.Next()
+	}
+}
+
+func (mw *Middleware) OverGeneralOnly() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		email := ctx.GetString(consts.SessionUserEmail)
+
+		if !mw.config.WhitelistUsers.IsGeneralUser(email) || !mw.config.WhitelistUsers.IsAdminUser(email) {
+			ctx.AbortWithStatus(http.StatusForbidden)
+			return
+		}
+
+		ctx.Next()
+	}
+}
+
 func (mw *Middleware) AdminOnly() gin.HandlerFunc {
 	return func(ctx *gin.Context) {
-		email := ctx.GetString(consts.UserEmail)
+		email := ctx.GetString(consts.SessionUserEmail)
 
 		if !mw.config.WhitelistUsers.IsAdminUser(email) {
 			ctx.AbortWithStatus(http.StatusForbidden)

--- a/router/middlewares/session.go
+++ b/router/middlewares/session.go
@@ -25,7 +25,10 @@ func (mw *Middleware) CheckSession() gin.HandlerFunc {
 			return
 		}
 
-		ctx.Set(consts.UserEmail, s.Email)
+		ctx.Set(consts.SessionUserUUID, s.UserUUID)
+		ctx.Set(consts.SessionUserEmail, s.Email)
+		ctx.Set(consts.SessionUserName, s.Name)
+		ctx.Set(consts.SessionUserRole, s.Role)
 
 		ctx.Next()
 	}

--- a/router/router_wire.go
+++ b/router/router_wire.go
@@ -24,6 +24,7 @@ func newServer(logger *zap.Logger, db *gorm.DB) (*Server, error) {
 		wire.Struct(new(config.Config), "*"),
 		wire.Bind(new(config.IConfig), new(*config.Config)),
 		wire.Bind(new(repos.IRepository), new(*repos.Repository)),
+		wire.Bind(new(repos.UserRepo), new(*repos.Repository)),
 	)
 
 	return nil, nil

--- a/router/utils/whitelist.go
+++ b/router/utils/whitelist.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"github.com/lc-tut/club-portal/models"
+	"github.com/lc-tut/club-portal/repos"
 	"github.com/spf13/viper"
 	"strings"
 )
@@ -14,6 +16,7 @@ type WhitelistInfo interface {
 	IsDomainUser(email string) bool
 	IsGeneralUser(email string) bool
 	IsAdminUser(email string) bool
+	AddGeneralUser(email string)
 }
 
 type Whitelist struct {
@@ -79,10 +82,23 @@ func (w *Whitelist) IsGeneralUser(email string) bool {
 	return false
 }
 
-func NewWhitelist() WhitelistInfo {
+func (w *Whitelist) AddGeneralUser(email string) {
+	w.generalEmails = append(w.generalEmails, email)
+	w.users = append(w.users, email)
+}
+
+func NewWhitelist(userRepo repos.UserRepo) (WhitelistInfo, error) {
 	ed := viper.GetStringSlice("email_domains")
 	ae := viper.GetStringSlice("admin_emails")
-	ge := viper.GetStringSlice("general_emails") // will deprecate
+
+	generalUser, err := userRepo.GetAllGeneralUser()
+
+	if err != nil {
+		return nil, err
+	}
+
+	typedGeneralUsers := models.GeneralUserSlice(generalUser)
+	ge := typedGeneralUsers.GetEmails()
 
 	users := append(ge, ae...)
 
@@ -93,5 +109,5 @@ func NewWhitelist() WhitelistInfo {
 		generalEmails: ge,
 	}
 
-	return w
+	return w, nil
 }

--- a/router/utils/whitelist.go
+++ b/router/utils/whitelist.go
@@ -82,7 +82,7 @@ func (w *Whitelist) IsGeneralUser(email string) bool {
 func NewWhitelist() WhitelistInfo {
 	ed := viper.GetStringSlice("email_domains")
 	ae := viper.GetStringSlice("admin_emails")
-	ge := viper.GetStringSlice("general_emails")
+	ge := viper.GetStringSlice("general_emails") // will deprecate
 
 	users := append(ge, ae...)
 

--- a/router/v1/club.go
+++ b/router/v1/club.go
@@ -35,7 +35,7 @@ func (h *Handler) GetClub() gin.HandlerFunc {
 	}
 }
 
-type CreatePostData struct {
+type ClubCreatePostData struct {
 	Name            string                         `json:"name"`
 	Description     string                         `json:"description"`
 	Campus          uint8                          `json:"campus"`
@@ -51,7 +51,7 @@ type CreatePostData struct {
 
 func (h *Handler) CreateClub() gin.HandlerFunc {
 	return func(ctx *gin.Context) {
-		pd := &CreatePostData{}
+		pd := &ClubCreatePostData{}
 
 		pageArgs, err := h.makeCreateArgs(ctx, pd)
 
@@ -68,7 +68,7 @@ func (h *Handler) CreateClub() gin.HandlerFunc {
 	}
 }
 
-func (*Handler) makeCreateArgs(ctx *gin.Context, pd *CreatePostData) (*repos.ClubPageCreateArgs, error) {
+func (*Handler) makeCreateArgs(ctx *gin.Context, pd *ClubCreatePostData) (*repos.ClubPageCreateArgs, error) {
 	if err := ctx.ShouldBindJSON(pd); err != nil {
 		return nil, err
 	}

--- a/router/v1/user.go
+++ b/router/v1/user.go
@@ -1,10 +1,27 @@
 package v1
 
-import "github.com/gin-gonic/gin"
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/lc-tut/club-portal/consts"
+	"github.com/lc-tut/club-portal/models"
+	"net/http"
+)
 
 func (h *Handler) GetUser() gin.HandlerFunc {
 	return func(ctx *gin.Context) {
-		// TODO: implement
+		uuid := ctx.GetString(consts.SessionUserUUID)
+		email := ctx.GetString(consts.SessionUserEmail)
+		name := ctx.GetString(consts.SessionUserName)
+		role := ctx.GetString(consts.SessionUserRole)
+
+		res := &models.UserResponse{
+			UserUUID: uuid,
+			Email:    email,
+			Name:     name,
+			Role:     role,
+		}
+
+		ctx.JSON(http.StatusOK, res)
 	}
 }
 

--- a/router/v1/user.go
+++ b/router/v1/user.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/lc-tut/club-portal/consts"
 	"github.com/lc-tut/club-portal/models"
 	"net/http"
@@ -9,13 +10,13 @@ import (
 
 func (h *Handler) GetUser() gin.HandlerFunc {
 	return func(ctx *gin.Context) {
-		uuid := ctx.GetString(consts.SessionUserUUID)
+		userUUID := ctx.GetString(consts.SessionUserUUID)
 		email := ctx.GetString(consts.SessionUserEmail)
 		name := ctx.GetString(consts.SessionUserName)
 		role := ctx.GetString(consts.SessionUserRole)
 
 		res := &models.UserResponse{
-			UserUUID: uuid,
+			UserUUID: userUUID,
 			Email:    email,
 			Name:     name,
 			Role:     role,
@@ -27,14 +28,46 @@ func (h *Handler) GetUser() gin.HandlerFunc {
 
 func (h *Handler) GetUserUUID() gin.HandlerFunc {
 	return func(ctx *gin.Context) {
-		uuid := ctx.GetString(consts.UserUUIDKeyName)
+		userUUID := ctx.GetString(consts.UserUUIDKeyName)
 		role := ctx.GetString(consts.SessionUserRole)
-		user, err := h.repo.GetUserByUUIDFromRole(uuid, role)
+		user, err := h.repo.GetUserByUUIDFromRole(userUUID, role)
 
 		if err != nil {
 			ctx.Status(http.StatusInternalServerError)
 		} else {
 			ctx.JSON(http.StatusOK, user.ToUserResponse())
+		}
+	}
+}
+
+type GUserCreatePostData struct {
+	Email string `json:"email"`
+	Name  string `json:"name"`
+}
+
+func (h *Handler) CreateGeneralUser() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		pd := &GUserCreatePostData{}
+
+		if err := ctx.ShouldBindJSON(pd); err != nil {
+			ctx.Status(http.StatusBadRequest)
+			return
+		}
+
+		userUUID, err := uuid.NewRandom()
+
+		if err != nil {
+			ctx.Status(http.StatusInternalServerError)
+			return
+		}
+
+		res, err := h.repo.CreateGeneralUser(userUUID.String(), pd.Email, pd.Name)
+
+		if err != nil {
+			ctx.Status(http.StatusInternalServerError)
+		} else {
+			h.config.WhitelistUsers.AddGeneralUser(res.GetEmail())
+			ctx.JSON(http.StatusCreated, res)
 		}
 	}
 }

--- a/router/v1/user.go
+++ b/router/v1/user.go
@@ -27,6 +27,14 @@ func (h *Handler) GetUser() gin.HandlerFunc {
 
 func (h *Handler) GetUserUUID() gin.HandlerFunc {
 	return func(ctx *gin.Context) {
-		// TODO: implement
+		uuid := ctx.GetString(consts.UserUUIDKeyName)
+		role := ctx.GetString(consts.SessionUserRole)
+		user, err := h.repo.GetUserByUUIDFromRole(uuid, role)
+
+		if err != nil {
+			ctx.Status(http.StatusInternalServerError)
+		} else {
+			ctx.JSON(http.StatusOK, user.ToUserResponse())
+		}
 	}
 }

--- a/router/v1/v1_router.go
+++ b/router/v1/v1_router.go
@@ -38,6 +38,7 @@ func (r *Router) AddRouter() {
 		userGroup := v1Group.Group("/users", r.middleware.CheckSession())
 		{
 			userGroup.GET("/", h.GetUser())
+			userGroup.POST("/", r.middleware.AdminOnly(), h.CreateGeneralUser())
 			userGroup.GET("/:uuid", r.middleware.SetUserUUIDKey(), r.middleware.PersonalOrAdminOnly(), h.GetUserUUID())
 		}
 		clubGroup := v1Group.Group("/clubs")

--- a/router/v1/v1_router.go
+++ b/router/v1/v1_router.go
@@ -40,6 +40,7 @@ func (r *Router) AddRouter() {
 			userGroup.GET("/", h.GetUser())
 			userGroup.POST("/", r.middleware.AdminOnly(), h.CreateGeneralUser())
 			userGroup.GET("/:uuid", r.middleware.SetUserUUIDKey(), r.middleware.PersonalOrAdminOnly(), h.GetUserUUID())
+			userGroup.PUT("/:uuid", r.middleware.SetUserUUIDKey(), r.middleware.OverGeneralOnly(), h.UpdateUser())
 		}
 		clubGroup := v1Group.Group("/clubs")
 		{

--- a/router/v1/v1_router.go
+++ b/router/v1/v1_router.go
@@ -35,18 +35,18 @@ func (r *Router) AddRouter() {
 
 	v1Group := r.rg.Group("/v1")
 	{
-		userGroup := v1Group.Group("/user")
+		userGroup := v1Group.Group("/users", r.middleware.CheckSession())
 		{
 			userGroup.GET("/", h.GetUser())
-			userGroup.GET("/:uuid", r.middleware.AdminOnly(), h.GetUserUUID())
+			userGroup.GET("/:uuid", r.middleware.SetUserUUIDKey(), r.middleware.PersonalOrAdminOnly(), h.GetUserUUID())
 		}
 		clubGroup := v1Group.Group("/clubs")
 		{
 			clubGroup.GET("/", h.GetAllClub())
-			clubGroup.POST("/", h.CreateClub())
+			clubGroup.POST("/", r.middleware.CheckSession(), r.middleware.OverGeneralOnly(), h.CreateClub())
 			clubGroup.GET("/:clubslug", r.middleware.SetClubIDKey(), h.GetClub())
-			clubGroup.PUT("/:clubslug", r.middleware.SetClubIDKey(), h.UpdateClub())
-			clubGroup.DELETE("/:clubslug", r.middleware.SetClubIDKey(), h.DeleteClub())
+			clubGroup.PUT("/:clubslug", r.middleware.CheckSession(), r.middleware.SetClubIDKey(), r.middleware.OverGeneralOnly(), h.UpdateClub())
+			clubGroup.DELETE("/:clubslug", r.middleware.CheckSession(), r.middleware.SetClubIDKey(), r.middleware.AdminOnly(), h.DeleteClub())
 		}
 	}
 }

--- a/router/wire_gen.go
+++ b/router/wire_gen.go
@@ -24,13 +24,16 @@ func newServer(logger *zap.Logger, db *gorm.DB) (*Server, error) {
 	engine := newGinEngine(logger, store)
 	csrfCookieOption := config.NewCSRFCookieOption()
 	oauth2Config := config.NewOAuth2Config()
-	whitelistInfo := utils.NewWhitelist()
+	repository := repos.NewRepository(logger, db)
+	whitelistInfo, err := utils.NewWhitelist(repository)
+	if err != nil {
+		return nil, err
+	}
 	configConfig := &config.Config{
 		CSRFCookieOptions: csrfCookieOption,
 		GoogleOAuthConfig: oauth2Config,
 		WhitelistUsers:    whitelistInfo,
 	}
-	repository := repos.NewRepository(logger, db)
 	server := registerRouters(engine, configConfig, logger, repository)
 	return server, nil
 }

--- a/utils/validate.go
+++ b/utils/validate.go
@@ -57,3 +57,12 @@ func ToClubType(i uint8) (consts.ClubType, error) {
 		return typed, nil
 	}
 }
+
+func ToUserType(s string) (consts.UserType, error) {
+	switch s {
+	case "admin", "general", "domain":
+		return consts.UserType(s), nil
+	default:
+		return "", errors.New("no role: " + s)
+	}
+}


### PR DESCRIPTION
`/api/v1/users` でのルータを追加

`config.toml` で `general_users` の管理を廃止