### PR TITLE
GitHub Actions の更新

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   push:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/redoc.yml
+++ b/.github/workflows/redoc.yml
@@ -1,0 +1,26 @@
+name: redoc
+
+on:
+  push:
+    paths:
+      - openapi.yaml
+
+jobs:
+  redoc:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          cache: npm
+      - name: npx redoc-cli
+        run: npx redoc-cli bundle openapi.yaml -o redoc/index.html
+      - name: deploy gh-pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./redoc
+          publish_branch: redoc
+          cname: club-portal-api.linux.it.teu.ac.jp


### PR DESCRIPTION
redoc の ci と実行環境を Ubuntu 20.04 にした