### PR TITLE
Search API の追加

### DIFF
--- a/models/clubs/search.go
+++ b/models/clubs/search.go
@@ -1,0 +1,11 @@
+package clubs
+
+func (p Pages) ToClubSearchResponse() *ClubSearchResponse {
+	externalInfo := p.ToExternalInfo()
+
+	return &ClubSearchResponse{Result: externalInfo}
+}
+
+type ClubSearchResponse struct {
+	Result []ClubPageExternalInfo `json:"result"`
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -433,6 +433,29 @@ paths:
           description: 認証していない状態でアクセスした場合に返されます。
         500:
           description: サーバ側でエラーが発生した場合に返されます。
+  /v1/clubs/search:
+    get:
+      tags:
+        - club
+      summary: サークルを検索します。
+      parameters:
+        - in: query
+          name: content
+          schema:
+            type: string
+          required: true
+          description: 検索ワード
+      responses:
+        200:
+          description: 正常に取得した場合に返されます。
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClubPage-External'
+        400:
+          description: リクエストが不正の場合に返されます。
+        500:
+          description: サーバ側でエラーが発生した場合に返されます。
   /v1/clubs/slug/{clubSlug}:
     get:
       tags:

--- a/repos/clubs/repo.go
+++ b/repos/clubs/repo.go
@@ -19,6 +19,7 @@ type IClubRepository interface {
 	ClubActivityDetailRepo
 	ClubRemarkRepo
 	ClubThumbnailRepo
+	ClubSearchRepo
 }
 
 type ClubRepository struct {

--- a/repos/clubs/search.go
+++ b/repos/clubs/search.go
@@ -1,0 +1,30 @@
+package clubs
+
+import (
+	"errors"
+	"github.com/lc-tut/club-portal/models/clubs"
+	"gorm.io/gorm"
+)
+
+type ClubSearchRepo interface {
+	DoSearch(content string) ([]clubs.ClubPageExternalInfo, error)
+}
+
+func (r *ClubRepository) DoSearch(content string) ([]clubs.ClubPageExternalInfo, error) {
+	pages := make([]clubs.ClubPage, 0)
+	tx := r.db.Where("visible is true").Where("description LIKE ? OR short_description LIKE ?", "%"+content+"%", "%"+content+"%").Preload("Thumbnail", func(db *gorm.DB) *gorm.DB {
+		selectQuery := "club_thumbnails.thumbnail_id, club_thumbnails.club_uuid, ut.path"
+		joinQuery := "inner join uploaded_thumbnails as ut using (thumbnail_id)"
+		return db.Joins(joinQuery).Select(selectQuery)
+	}).Find(&pages)
+
+	if err := tx.Error; errors.Is(err, gorm.ErrRecordNotFound) {
+		r.logger.Info(err.Error())
+		return make([]clubs.ClubPageExternalInfo, 0), nil
+	} else if err != nil {
+		r.logger.Error(err.Error())
+		return nil, err
+	}
+
+	return clubs.Pages(pages).ToExternalInfo(), nil
+}

--- a/router/v1/search.go
+++ b/router/v1/search.go
@@ -1,0 +1,29 @@
+package v1
+
+import (
+	"github.com/gin-gonic/gin"
+	"net/http"
+)
+
+type SearchContent struct {
+	Content string `form:"content" binding:"required"`
+}
+
+func (h *Handler) GetSearch() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		searchContent := &SearchContent{}
+
+		if err := ctx.ShouldBind(searchContent); err != nil {
+			ctx.Status(http.StatusBadRequest)
+			return
+		}
+
+		pages, err := h.repo.DoSearch(searchContent.Content)
+
+		if err != nil {
+			ctx.Status(http.StatusInternalServerError)
+		} else {
+			ctx.JSON(http.StatusOK, pages)
+		}
+	}
+}

--- a/router/v1/v1_router.go
+++ b/router/v1/v1_router.go
@@ -58,6 +58,7 @@ func (r *Router) AddRouter() {
 			clubGroup.GET("/", h.GetAllClub())
 			clubGroup.POST("/", r.middleware.CheckSession(), r.middleware.GeneralOnly(), h.CreateClub())
 			clubGroup.PUT("/", r.middleware.CheckSession(), r.middleware.GeneralOnly(), h.UpdateClub())
+			clubGroup.GET("/search", h.GetSearch())
 			clubGroup.GET("/slug/:clubslug", r.middleware.SetClubSlugKey(), r.middleware.SetIsRestrictedSession(), h.GetClubFromSlug())
 			personalClubGroup := clubGroup.Group("/uuid/:clubuuid", r.middleware.SetClubUUIDKey())
 			{


### PR DESCRIPTION
`/api/v1/clubs/search` に query 方式の API を追加

usage:
`/api/v1/clubs/search?content=バドミントン`