### PR TITLE
fix:全ユーザ取得時のnilポインタ参照を修正

### DIFF
--- a/repos/admins/user.go
+++ b/repos/admins/user.go
@@ -49,7 +49,7 @@ func (r *AdminRepository) GetAllUser() ([]models.UserInfo, error) {
 		return nil, err
 	}
 
-	allUsers := make([]models.UserInfo, len(domainUsers)+len(generalUsers)+len(adminUsers))
+	allUsers := make([]models.UserInfo, 0, len(domainUsers)+len(generalUsers)+len(adminUsers))
 
 	for _, user := range domainUsers {
 		allUsers = append(allUsers, &user)

--- a/router/utils/validate.go
+++ b/router/utils/validate.go
@@ -18,14 +18,12 @@ func ByteSliceToSessionData(b []byte) (*SessionData, error) {
 	return model, nil
 }
 
-func ToUserInfoResponse(users []usermodels.UserInfo) []usermodels.UserResponse {
-	res := make([]usermodels.UserResponse, len(users))
-
-	for i, user := range users {
-		res[i] = *user.ToUserResponse()
-	}
-
-	return res
+func ToUserInfoResponse(users []usermodels.UserInfo) []usermodels.UserResponse {    
+    res := make([]usermodels.UserResponse, len(users))
+    for i, user := range users {
+        res[i] = *user.ToUserResponse()
+    }
+    return res
 }
 
 func ValidateToContentArgs(models []clubmodels.ContentRequest) []string {


### PR DESCRIPTION
"error": "runtime error: invalid memory address or nil pointer dereference"がclub-portal/router/utils.ToUserInfoResponseにて発生していたため、関連する箇所を修正しました。