### PR TITLE
docker-compose.yml の修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - redis-network
 
   mariadb:
-    image: mariadb:latest
+    image: mariadb:10
     container_name: mariadb
     ports:
       - "3306:3306"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: club-portal
     container_name: club-portal
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080"
     volumes:
       - ./images:/root/images
       - ./thumbnails:/root/thumbnails
@@ -31,7 +31,7 @@ services:
     image: mariadb:10
     container_name: mariadb
     ports:
-      - "3306:3306"
+      - "127.0.0.1:3306:3306"
     volumes:
       - ./cfg/mariadb/conf:/etc/mysql/conf.d
       - ./cfg/mariadb/sql:/docker-entrypoint-initdb.d


### PR DESCRIPTION
# Overview
## MariaDB

本番環境では MariaDB のバージョンが 10 系で動いているのでそれに合わせてます。
最新バージョンは 11 ですが、10 と 11 でデータの互換性がないので一旦開発環境をそっちに合わせる形です。

log: 
```
[root@lc-club-portal club_portal]# docker exec -it mariadb /bin/bash
root@c028dfe220ce:/# mysql --version
mysql  Ver 15.1 Distrib 10.11.2-MariaDB, for debian-linux-gnu (x86_64) using  EditLine wrapper
```

## Port

セキュリティの面から `"8080:8080"` とかのポートフォワーディングを `"127.0.0.1:8080:8080"` に変更しました。
本当は開発環境用と本番環境用で分けた方がいいんですが、流石に大きくなるので暫定処置です。
