### PR TITLE
add:txの動作順番による不具合を防ぐため、savepointを追加

### DIFF
--- a/repos/clubs/page.go
+++ b/repos/clubs/page.go
@@ -251,7 +251,7 @@ func (r *ClubRepository) CreatePage(uuid string, args ClubPageCreateArgs) (*club
 
 	err := r.db.Transaction(func(tx *gorm.DB) error {
 
-		tx.SavePoint("CreatePage_1")
+		tx.SavePoint("CreatePage_init_point")
 
 		if err := tx.Create(page).Error; err != nil {
 			return err
@@ -290,16 +290,16 @@ func (r *ClubRepository) CreatePage(uuid string, args ClubPageCreateArgs) (*club
 		}
 		
 		// 一度トランザクションをsave
-		tx.SavePoint("CreatePage_2")
+		tx.SavePoint("CreatePage_save")
 		
 
 		if err := r.CreateActivityDetailWithTx(tx, uuid, args.ActivityDetails); err != nil {
-			tx.RollbackTo("CreatePage")
+			tx.RollbackTo("CreatePage_init_point")
 			return err
 		}
 
 		if err := r.CreateTPRemarkWithTx(tx, uuid, args.TPRemark); err != nil {
-			tx.RollbackTo("CreatePage")
+			tx.RollbackTo("CreatePage_init_point")
 			return err
 		}
 

--- a/repos/clubs/page.go
+++ b/repos/clubs/page.go
@@ -251,8 +251,6 @@ func (r *ClubRepository) CreatePage(uuid string, args ClubPageCreateArgs) (*club
 
 	err := r.db.Transaction(func(tx *gorm.DB) error {
 
-		tx.SavePoint("CreatePage_init_point")
-
 		if err := tx.Create(page).Error; err != nil {
 			return err
 		}
@@ -287,19 +285,13 @@ func (r *ClubRepository) CreatePage(uuid string, args ClubPageCreateArgs) (*club
 
 		if err := r.CreatePlaceWithTx(tx, args.Places); err != nil {
 			return err
-		}
-		
-		// 一度トランザクションをsave
-		tx.SavePoint("CreatePage_save")
-		
+		}		
 
 		if err := r.CreateActivityDetailWithTx(tx, uuid, args.ActivityDetails); err != nil {
-			tx.RollbackTo("CreatePage_init_point")
 			return err
 		}
 
 		if err := r.CreateTPRemarkWithTx(tx, uuid, args.TPRemark); err != nil {
-			tx.RollbackTo("CreatePage_init_point")
 			return err
 		}
 

--- a/repos/clubs/page.go
+++ b/repos/clubs/page.go
@@ -250,6 +250,9 @@ func (r *ClubRepository) CreatePage(uuid string, args ClubPageCreateArgs) (*club
 	}
 
 	err := r.db.Transaction(func(tx *gorm.DB) error {
+
+		tx.SavePoint("CreatePage_1")
+
 		if err := tx.Create(page).Error; err != nil {
 			return err
 		}
@@ -285,12 +288,18 @@ func (r *ClubRepository) CreatePage(uuid string, args ClubPageCreateArgs) (*club
 		if err := r.CreatePlaceWithTx(tx, args.Places); err != nil {
 			return err
 		}
+		
+		// 一度トランザクションをsave
+		tx.SavePoint("CreatePage_2")
+		
 
 		if err := r.CreateActivityDetailWithTx(tx, uuid, args.ActivityDetails); err != nil {
+			tx.RollbackTo("CreatePage")
 			return err
 		}
 
 		if err := r.CreateTPRemarkWithTx(tx, uuid, args.TPRemark); err != nil {
+			tx.RollbackTo("CreatePage")
 			return err
 		}
 


### PR DESCRIPTION
SavePointを作らない場合、CreateActivityDetailWithTxにてTime,PlaceのIDがなく、Errorとなって作成に失敗してしまう。それを防止するためにSavePointを実装した